### PR TITLE
Fixed window title and bevy features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ Cargo.lock
 
 # Build
 /target
+
+# IntellJ
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.6"
 bevy_egui = "0.10"
 strum = "0.17.1"
 strum_macros = "0.17.1"
+
+[dependencies.bevy]
+version = "0.6"
+default-features = false

--- a/src/bottom_panel.rs
+++ b/src/bottom_panel.rs
@@ -22,6 +22,7 @@ pub(self) fn bottom_panel(
     mut settings: ResMut<ToolbarSettings>,
 ) {
     let prime = windows.get_primary_mut().unwrap();
+
     egui::TopBottomPanel::bottom("Window state").show(egui.ctx(), |ui| {
         ui.horizontal(|ui| {
             if settings.setting_toggles.title {

--- a/src/bottom_panel.rs
+++ b/src/bottom_panel.rs
@@ -22,7 +22,6 @@ pub(self) fn bottom_panel(
     mut settings: ResMut<ToolbarSettings>,
 ) {
     let prime = windows.get_primary_mut().unwrap();
-
     egui::TopBottomPanel::bottom("Window state").show(egui.ctx(), |ui| {
         ui.horizontal(|ui| {
             if settings.setting_toggles.title {

--- a/src/top_panel.rs
+++ b/src/top_panel.rs
@@ -111,6 +111,7 @@ fn get_startup_resolution(mut windows: ResMut<Windows>, mut settings: ResMut<Too
     let prime = windows.get_primary_mut().unwrap();
     settings.current_window_size.width = prime.requested_width();
     settings.current_window_size.height = prime.requested_height();
+    settings.title = prime.title().to_string();
 }
 
 pub(self) fn top_panel(


### PR DESCRIPTION
Fixed:
- [x] window title always set to `bevy` on startup instead of the actual window title
- [x] bevy was compiling with very default features (render, audio, etc etc)